### PR TITLE
replace io/ioutil

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -146,7 +146,7 @@ func saveKeyFile(cluster string, ssh sshConfig, force bool) error {
 		return fmt.Errorf("file %s already exist, use force option to overwrite it", privateKeyFile)
 	}
 
-	err = ioutil.WriteFile(privateKeyFile, privateKey, 0600)
+	err = os.WriteFile(privateKeyFile, privateKey, 0600)
 	cobra.CheckErr(err)
 
 	// Write the certificate
@@ -157,7 +157,7 @@ func saveKeyFile(cluster string, ssh sshConfig, force bool) error {
 		return fmt.Errorf("file %s already exist, use force option to overwrite it", certificateFile)
 	}
 
-	err = ioutil.WriteFile(certificateFile, certificate, 0600)
+	err = os.WriteFile(certificateFile, certificate, 0600)
 	cobra.CheckErr(err)
 
 	if verbose {
@@ -402,7 +402,7 @@ func (c *nutanixCluster) clusterRequest(method string, path string, payload []by
 		return nil, fmt.Errorf("internal Error")
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -109,7 +108,7 @@ If option enabled retrieve SSH key/cert and add them to ssh-agent or in file in 
 			cobra.CheckErr(fmt.Errorf("file %s already exist, use force option to overwrite it", kubeconfig))
 		}
 
-		err = ioutil.WriteFile(kubeconfig, []byte(kubeconfigResponse.KubeConfig), 0600)
+		err = os.WriteFile(kubeconfig, []byte(kubeconfigResponse.KubeConfig), 0600)
 		cobra.CheckErr(err)
 
 		if verbose {


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code (SA1019)